### PR TITLE
feat(scripts): Enhance the deploy-s3-cf script

### DIFF
--- a/scripts/deploy-s3-cf.sh
+++ b/scripts/deploy-s3-cf.sh
@@ -1,39 +1,41 @@
 #!/bin/sh
 
-set -e
-
 help() {
   echo "Usage: $0 [-h] [-v] -d <SOURCE_DIR> -b <AWS_S3_BUCKET_URI> -i <AWS_CF_DISTRIBUTION_ID>"
   echo "  -h    Display this help message"
   echo "  -v    Verbose output (commands are being executed)"
-  echo "  -d    Source directory"
-  echo "  -b    S3 bucket URI (s3://<bucket-name>/[<directory>])"
-  echo "  -i    CloudFront Distribution ID"
+  echo "  -d    Local source directory"
+  echo "  -b    AWS S3 bucket URI (s3://<bucket-name>/[<directory>])"
+  echo "  -i    AWS CloudFront Distribution ID"
 }
 
 log() {
   if [ $# -eq 2 ]; then
-    printf "%-32s %s\n" "${1}:" "$2" >&2
+    printf " -> %-32s %s\n" "${1}:" "$2" >&2
   else
     echo "$@" >&2
   fi
 }
 
-# Recursive copy to S3
-# ====================
+# Copy to S3
+# ==========
+# Wrapper to recursively copy the source directory to the S3 bucket URI
 #
-# Requires the source directory (-d) and the S3 Bucket URI (-b)
+# Requires:
+# - the source directory (-d / $SOURCE_DIR)
+# - the S3 Bucket URI (-b / $AWS_S3_BUCKET_URI)
 #
 s3_cp() {
   src_dir="${1}"
   s3_uri="${2}"
   s3_bucket=$(echo "${s3_uri}" | awk -F/ '{print $3}')
-  s3_dir=$(echo "${s3_uri}" | awk -F/ 'BEGIN { OFS="/"; ORS="/"; } { for (i=4; i<=NF; i++) printf "%s%s", $i, (i<NF ? OFS : ORS)}' | sed 's|//|/|')
+  s3_dir=/$(echo "${s3_uri}" | awk -F/ 'BEGIN { OFS="/"; ORS=""; } { for (i=4; i<=NF; i++) printf "%s%s", $i, (i<NF ? OFS : ORS)}' | sed 's|/*$||')
   log "Source Directory" "${src_dir}"
   log "Destination S3 bucket name" "${s3_bucket}"
   log "Destination S3 bucket directory" "${s3_dir}"
+  cmd_opts="--recursive"
   test "${VERBOSE}" -gt 0 && set -x
-  aws s3 cp --recursive "${src_dir}" "${s3_uri}"
+  aws s3 cp ${cmd_opts} "${src_dir}" "s3://${s3_bucket}${s3_dir}"
   ret=$?
   test "${VERBOSE}" -gt 0 && set +x
   return ${ret}
@@ -41,45 +43,54 @@ s3_cp() {
 
 # CloudFront invalidation
 # =======================
+# Wrapper to retrieve the Invalidation ID for the `cf_wait` function.
 #
-# This is wrapped to retrieve the Invalidation ID for the foll
-#
-# Requires the CloudFront Distribution ID (-i)
+# Requires:
+# - the CloudFront Distribution ID (-i / $AWS_CF_DISTRIBUTION_ID)
 #
 cf_invalidate() {
-  d_id="${1}"
-  log "CloudFront Distribution ID" "${d_id}"
+  cf_dist_id="${1}"
+  log "CloudFront Distribution ID" "${cf_dist_id}"
   test "${VERBOSE}" -gt 0 && set -x
-  aws cloudfront create-invalidation --distribution-id "${d_id}" --paths '/*' | jq -r .Invalidation.Id
+  val=$(aws cloudfront create-invalidation --distribution-id "${cf_dist_id}" --paths '/*' --output json)
   ret=$?
   test "${VERBOSE}" -gt 0 && set +x
+  echo "${val}" | jq -r .Invalidation.Id
   return ${ret}
 }
 
 # CloudFront wait-to-finish invalidation
 # ======================================
+# This just waits for the CloudFront Invalidation to finish.
 #
-# Requires the CloudFront Distribution ID (-i) and the Invalidation ID (value from cf_invalidate)
+# Requires:
+# - the CloudFront Distribution ID (-i / $AWS_CF_DISTRIBUTION_ID)
+# - the CloudFront Invalidation ID (value from cf_invalidate)
 #
 cf_wait() {
-  d_id="${1}"
-  inv_id="${2}"
-  log "CloudFront Invalidation ID" "${inv_id}"
+  cf_dist_id="${1}"
+  cf_inv_id="${2}"
+  log "CloudFront Invalidation ID" "${cf_inv_id}"
   test "${VERBOSE}" -gt 0 && set -x
-  aws cloudfront wait invalidation-completed --distribution-id "${d_id}" --id "${inv_id}"
+  aws cloudfront wait invalidation-completed --distribution-id "${cf_dist_id}" --id "${cf_inv_id}"
   ret=$?
   test "${VERBOSE}" -gt 0 && set +x
   return ${ret}
 }
 
 ########################################################################################
+set -e
 
-# Parse command line
-#
 OPTIND=1
 VERBOSE=0
+ERR=0
+
+# Use the old input variables
+test -n "${AWS_S3_BUCKET}" && AWS_S3_BUCKET_URI="s3://${AWS_S3_BUCKET}/"
+
+# Parse command line
 while getopts "h?d:b:i:v?" opt; do
-  case "$opt" in
+  case "${opt}" in
     h)
       help
       exit 0
@@ -93,17 +104,25 @@ while getopts "h?d:b:i:v?" opt; do
 done
 
 # Validate inputs
-#
-test -z "${SOURCE_DIR}" && help && exit 1
-test -z "${AWS_S3_BUCKET_URI}" && help && exit 1
-test -z "${AWS_CF_DISTRIBUTION_ID}" && help && exit 1
-(echo "${AWS_S3_BUCKET_URI}" | grep -Eq '^s3://[a-zA-Z0-9._-]+/' ) || (
-  log "Invalid S3 URI: ${AWS_S3_BUCKET_URI} (It needs to be in the following format: s3://<bucket-name>/[<directory>])" && \
-  exit 1 \
-)
+test -z "${SOURCE_DIR}" && log "!!! No source directory specified" && ERR=1
+test -z "${AWS_CF_DISTRIBUTION_ID}" && log "!!! No CloudFront Distribution ID specified" && ERR=1
+test -z "${AWS_S3_BUCKET_URI}" && log "!!! No S3 Bucket URI specified" && ERR=1
+test "${ERR}" -eq 1 && help && exit 1
+
+if (echo "${AWS_S3_BUCKET_URI}" | grep -Eq '^s3://[a-zA-Z0-9._-]+/')
+then
+  log "!!! Invalid S3 URI: ${AWS_S3_BUCKET_URI} (It needs to be in the following format: s3://<bucket-name>/[<directory>])"
+  ERR=1
+fi
+test "${ERR}" -gt 0 && exit 1
 
 # Run the operations
-#
+log "==> Files in S3 (copying)"
 s3_cp "${SOURCE_DIR}" "${AWS_S3_BUCKET_URI}"
-AWS_CF_INVALIDATION_ID=$(cf_invalidate "${AWS_CF_DISTRIBUTION_ID}" || exit 1)
+log "==> Files in S3 (copied)"
+
+log "==> CloudFront Invalidation (creating)"
+AWS_CF_INVALIDATION_ID=$(cf_invalidate "${AWS_CF_DISTRIBUTION_ID}")
+log "==> CloudFront Invalidation (waiting)"
 cf_wait "${AWS_CF_DISTRIBUTION_ID}" "${AWS_CF_INVALIDATION_ID}"
+log "==> CloudFront Invalidation (finished)"

--- a/scripts/deploy-s3-cf.sh
+++ b/scripts/deploy-s3-cf.sh
@@ -2,28 +2,108 @@
 
 set -e
 
-MISSING_ENV=0
+help() {
+  echo "Usage: $0 [-h] [-v] -d <SOURCE_DIR> -b <AWS_S3_BUCKET_URI> -i <AWS_CF_DISTRIBUTION_ID>"
+  echo "  -h    Display this help message"
+  echo "  -v    Verbose output (commands are being executed)"
+  echo "  -d    Source directory"
+  echo "  -b    S3 bucket URI (s3://<bucket-name>/[<directory>])"
+  echo "  -i    CloudFront Distribution ID"
+}
 
-if [[ -z "${SOURCE_DIR}" ]]; then
-  echo "SOURCE_DIR env must be set"
-  MISSING_ENV=1
-fi
+log() {
+  if [ $# -eq 2 ]; then
+    printf "%-32s %s\n" "${1}:" "$2" >&2
+  else
+    echo "$@" >&2
+  fi
+}
 
-if [[ -z "${AWS_S3_BUCKET}" ]]; then
-  echo "AWS_S3_BUCKET env must be set"
-  MISSING_ENV=1
-fi
+# Recursive copy to S3
+# ====================
+#
+# Requires the source directory (-d) and the S3 Bucket URI (-b)
+#
+s3_cp() {
+  src_dir="${1}"
+  s3_uri="${2}"
+  s3_bucket=$(echo "${s3_uri}" | awk -F/ '{print $3}')
+  s3_dir=$(echo "${s3_uri}" | awk -F/ 'BEGIN { OFS="/"; ORS="/"; } { for (i=4; i<=NF; i++) printf "%s%s", $i, (i<NF ? OFS : ORS)}' | sed 's|//|/|')
+  log "Source Directory" "${src_dir}"
+  log "Destination S3 bucket name" "${s3_bucket}"
+  log "Destination S3 bucket directory" "${s3_dir}"
+  test "${VERBOSE}" -gt 0 && set -x
+  aws s3 cp --recursive "${src_dir}" "${s3_uri}"
+  ret=$?
+  test "${VERBOSE}" -gt 0 && set +x
+  return ${ret}
+}
 
-if [[ -z "${AWS_CF_DISTRIBUTION_ID}" ]]; then
-  echo "AWS_CF_DISTRIBUTION_ID env must be set"
-  MISSING_ENV=1
-fi
+# CloudFront invalidation
+# =======================
+#
+# This is wrapped to retrieve the Invalidation ID for the foll
+#
+# Requires the CloudFront Distribution ID (-i)
+#
+cf_invalidate() {
+  d_id="${1}"
+  log "CloudFront Distribution ID" "${d_id}"
+  test "${VERBOSE}" -gt 0 && set -x
+  aws cloudfront create-invalidation --distribution-id "${d_id}" --paths '/*' | jq -r .Invalidation.Id
+  ret=$?
+  test "${VERBOSE}" -gt 0 && set +x
+  return ${ret}
+}
 
-if [[ "${MISSING_ENV}" == "1" ]]; then
-  exit 1
-fi
+# CloudFront wait-to-finish invalidation
+# ======================================
+#
+# Requires the CloudFront Distribution ID (-i) and the Invalidation ID (value from cf_invalidate)
+#
+cf_wait() {
+  d_id="${1}"
+  inv_id="${2}"
+  log "CloudFront Invalidation ID" "${inv_id}"
+  test "${VERBOSE}" -gt 0 && set -x
+  aws cloudfront wait invalidation-completed --distribution-id "${d_id}" --id "${inv_id}"
+  ret=$?
+  test "${VERBOSE}" -gt 0 && set +x
+  return ${ret}
+}
 
-aws s3 cp --recursive "${SOURCE_DIR}" "s3://${AWS_S3_BUCKET}/"
-AWS_CF_INVALIDATION_ID="$(aws cloudfront create-invalidation --distribution-id ${AWS_CF_DISTRIBUTION_ID} --paths '/*' | jq -r .Invalidation.Id)"
-echo "CloudFront Invalidation ID - ${AWS_CF_INVALIDATION_ID}"
-aws cloudfront wait invalidation-completed --distribution-id ${AWS_CF_DISTRIBUTION_ID} --id ${AWS_CF_INVALIDATION_ID}
+########################################################################################
+
+# Parse command line
+#
+OPTIND=1
+VERBOSE=0
+while getopts "h?d:b:i:v?" opt; do
+  case "$opt" in
+    h)
+      help
+      exit 0
+      ;;
+    d) SOURCE_DIR="${OPTARG}" ;;
+    b) AWS_S3_BUCKET_URI="${OPTARG}" ;;
+    i) AWS_CF_DISTRIBUTION_ID="${OPTARG}" ;;
+    v) VERBOSE=1 ;;
+    *) log "Unknown option ${opt}" ;;
+  esac
+done
+
+# Validate inputs
+#
+test -z "${SOURCE_DIR}" && help && exit 1
+test -z "${AWS_S3_BUCKET_URI}" && help && exit 1
+test -z "${AWS_CF_DISTRIBUTION_ID}" && help && exit 1
+(echo "${AWS_S3_BUCKET_URI}" | grep -Eq '^s3://[a-zA-Z0-9._-]+/' ) || (
+  log "Invalid S3 URI: ${AWS_S3_BUCKET_URI} (It needs to be in the following format: s3://<bucket-name>/[<directory>])" && \
+  exit 1 \
+)
+
+# Run the operations
+#
+s3_cp "${SOURCE_DIR}" "${AWS_S3_BUCKET_URI}"
+AWS_CF_INVALIDATION_ID=$(cf_invalidate "${AWS_CF_DISTRIBUTION_ID}" || exit 1)
+cf_wait "${AWS_CF_DISTRIBUTION_ID}" "${AWS_CF_INVALIDATION_ID}"


### PR DESCRIPTION
# Goals

- CI control via ENV variables
- user control (or CI overrides) via CLI options
- sanitized output format for CI readability (with colors!)
- verbose mode (prints the called `aws` CLI commands with all the options)
- backwards compatibility with the original code (via ENV control)
- valid for `sh`

# Implementation

## Usage

```
Usage: ./deploy-s3-cf.sh [-h] [-v] [-c] -s <SOURCE_DIR> -u <AWS_S3_BUCKET_URI> -i <AWS_CF_DISTRIBUTION_ID>

Options:
  -s SOURCE_DIR
        Local source directory
        REQUIRED (Can be also provided via environment variable)
  -u AWS_S3_BUCKET_URI
        AWS S3 bucket URI in the following format: 's3://<bucket>/[<subdir>]'
        REQUIRED (Can be also provided via environment variable or
        constructed from optional variables - see below)
  -i AWS_CF_DISTRIBUTION_ID
        AWS CloudFront Distribution ID
        REQUIRED (Can be also provided via environment variable)
  -c    Enable color output. Defaults to autodetection from TERM.
  -v    Enable verbose output (print API commands being executed).
  -h    Display this help message

Other environment variables:
  AWS_S3_BUCKET  Can be used to construct the S3 bucket URI.
                 If used, AWS_S3_BUCKET_URI doesn't have to be set.
  AWS_S3_PATH    Can be used to further specify bucket path in the S3 URI.
                 Has to start with '/'. Works only when AWS_S3_BUCKET is set.
                 Defaults to '/'.
  COLORIZE       Set to 1 to enable color output (or use -c). Set to 0 to disable.
                 By default it's autodetected from TERM.
  VERBOSE        Set to 1 to enable verbose output (or use -v). Defaults to 0.
```

## Notes

When all needed ENV variables are set, running the script without any options (`./deploy-s3-cf.sh`) just works!

The direct CLI way to set the destination in S3 supports subdirs and renders into `AWS_S3_BUCKET_URI`. The variable value is verified that it contains valid URL `s3://.../[...]`.

The `AWS_S3_BUCKET_URI` is required to be set, however there's a way to set it indirectly using the standard `AWS_S3_BUCKET` variable, which contains the bucket name. Also a subdir within the bucket can be specified using the optional `AWS_S3_PATH` variable. Value of this variable must begin with `/`.

Colorized output is automatically enabled:
- for capable terminal names
- when `CI=true` (works on GitLab)
