### PR TITLE
chore: Update versions

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,7 +9,7 @@ on:
 env:
   kubectl_version: 1.28.5 # https://github.com/kubernetes/kubernetes/releases
   helm_version: 3.13.3 # https://github.com/helm/helm/releases
-  sentry_cli_version: 2.19.4 # https://github.com/getsentry/sentry-cli/releases/
+  sentry_cli_version: 2.25.0 # https://github.com/getsentry/sentry-cli/releases/
   aws_cli_version: 2.12.7 # https://github.com/aws/aws-cli/tags
 
 jobs:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   kubectl_version: 1.28.5 # https://github.com/kubernetes/kubernetes/releases
-  helm_version: 3.12.1 # https://github.com/helm/helm/releases
+  helm_version: 3.13.3 # https://github.com/helm/helm/releases
   sentry_cli_version: 2.19.4 # https://github.com/getsentry/sentry-cli/releases/
   aws_cli_version: 2.12.7 # https://github.com/aws/aws-cli/tags
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -10,7 +10,7 @@ env:
   kubectl_version: 1.28.5 # https://github.com/kubernetes/kubernetes/releases
   helm_version: 3.13.3 # https://github.com/helm/helm/releases
   sentry_cli_version: 2.25.0 # https://github.com/getsentry/sentry-cli/releases/
-  aws_cli_version: 2.12.7 # https://github.com/aws/aws-cli/tags
+  aws_cli_version: 2.15.9 # https://github.com/aws/aws-cli/tags
 
 jobs:
   build:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -7,7 +7,7 @@ on:
       - '**'
 
 env:
-  kubectl_version: 1.27.3 # https://github.com/kubernetes/kubernetes/releases
+  kubectl_version: 1.28.5 # https://github.com/kubernetes/kubernetes/releases
   helm_version: 3.12.1 # https://github.com/helm/helm/releases
   sentry_cli_version: 2.19.4 # https://github.com/getsentry/sentry-cli/releases/
   aws_cli_version: 2.12.7 # https://github.com/aws/aws-cli/tags


### PR DESCRIPTION
No breaking changes found in the changelogs.

- aws-cli to 2.15.9
- sentry-cli to 2.25.0
- helm to 3.13.3
- kubectl to 1.28.5
